### PR TITLE
Allow users to customize manifest output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Hash's length.
 ### manifest `(string, default: './manifest.json')`
 Will output a `manifest` file with `key: value` pairs.
 
-### name `(function, default: ({dir, name, hash, ext}) => path.join(dir, name + '.' + hash + ext)
+### name `(function, default: ({dir, name, hash, ext}) => path.join(dir, name + '.' + hash + ext)`
 Pass a function to customise the name of the output file. The function is given an object of string values:
 
  - dir: the directory name as a string
@@ -78,7 +78,26 @@ Pass a function to customise the name of the output file. The function is given 
 1. The values will be either appended or replaced. If this file needs be recreated on each run, you'll have to manually delete it.
 2. `key`s are generated with files' `basename`. If you have `./input/A/one.css` & `./input/B/one.css`, only the last entry will exist.
 
+### updateEntry `(function, default: (originalName, hashedName) => { "fileName.css": "hashedName.css"}`
 
+Pass a function to customize manifest entries. The function is given
+
+- `originalName`: the original file name.
+- `hashedName`: the compiled file name.
+
+The function must return an object with the fileName as a key and whatever value you want. E.g.:
+
+```js
+function e(originalName, hashedName) {
+  var newData = {};
+  var key = path.parse(originalName).base;
+  var value = path.parse(hashedName).base;
+
+  newData[key] = { src: value, css: true };
+
+  return newData;
+}
+```
 
 See [PostCSS] docs for examples for your environment.
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = opts => {
             trim: 10,
             manifest: "./manifest.json",
             includeMap: false,
-            name: utils.defaultName
+            name: utils.defaultName,
+            updateEntry: utils.updateEntry
         },
         opts
     );
@@ -67,7 +68,7 @@ module.exports = opts => {
             }
 
             // create/update manifest.json
-            const newData = utils.data(originalName, result.opts.to);
+            const newData = utils.data(originalName, result.opts.to, opts);
 
             // You're probably thinking "Why not make all of the following async?!"
             // Well, using the async versions causes race conditions when this plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "postcss-hash",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {

--- a/utils.js
+++ b/utils.js
@@ -34,16 +34,19 @@ function rename(file, css, opts) {
 will return an object of {oldname: newname} to append/update into manifest file.
 input: ('./css/file.css', './file.a1b2c3d4e5.css')   output: {"file.css": "file.a1b2c3d4e5.css"}
 */
-function data(originalName, hashedName) {
-    var newData = {};
+function data(originalName, hashedName, opts) {
     var key = path.parse(originalName).base;
     var value = path.parse(hashedName).base;
 
-    newData[key] = value;
-    return newData;
+    return opts.updateEntry(key, value);
+}
+
+function updateEntry(originalName, hashedName) {
+    return { [originalName]: hashedName };
 }
 
 module.exports.hash = hash;
 module.exports.rename = rename;
 module.exports.defaultName = defaultName;
 module.exports.data = data;
+module.exports.updateEntry = updateEntry;


### PR DESCRIPTION
Sometimes we want to have more information in the generated manifest. I'm adding a new option `updateEntry` that allows users to return custom manifest entries instead of only `{ file: hashedFile }` that we have now.